### PR TITLE
Update `swift-cmark` reference to `swiftlang` org

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
         "version" : "509.0.2"

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.2")
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.2")
   ],
   targets: [
     .macro(


### PR DESCRIPTION
We're seeing issues with GitHub failing to follow the redirect, so it might help to get this updated to the new org.